### PR TITLE
Add support for being able to use an arbitrary nameid format and attribute name format

### DIFF
--- a/mujina-common/src/main/java/mujina/saml/SAMLBuilder.java
+++ b/mujina-common/src/main/java/mujina/saml/SAMLBuilder.java
@@ -194,8 +194,15 @@ public class SAMLBuilder {
     XSStringBuilder stringBuilder = (XSStringBuilder) Configuration.getBuilderFactory().getBuilder(XSString.TYPE_NAME);
 
     Attribute attribute = buildSAMLObject(Attribute.class, Attribute.DEFAULT_ELEMENT_NAME);
-    attribute.setName(name);
-    attribute.setNameFormat("urn:oasis:names:tc:SAML:2.0:attrname-format:uri");
+    if (name.contains("==")) {
+      String components[] = name.split("==", 2);
+
+      attribute.setName(components[1]);
+      attribute.setNameFormat(components[0]);
+    } else {
+      attribute.setName(name);
+      attribute.setNameFormat("urn:oasis:names:tc:SAML:2.0:attrname-format:uri");
+    }
     List<XSString> xsStringList = values.stream().map(value -> {
       XSString stringValue = stringBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSString.TYPE_NAME);
       stringValue.setValue(value);

--- a/mujina-idp/src/main/java/mujina/idp/SsoController.java
+++ b/mujina-idp/src/main/java/mujina/idp/SsoController.java
@@ -76,9 +76,8 @@ public class SsoController {
       nameidType = NameIDType.EMAIL;
     }
 
-    if (name.contains("=>")) {
-      String[] components = name.split("=>", 1);
-      name = components[1];
+    if (name.contains("==")) {
+      String[] components = name.split("==", 1);
       nameidType = components[0];
     }
 
@@ -102,9 +101,22 @@ public class SsoController {
 
     String assertionConsumerServiceURL = idpConfiguration.getAcsEndpoint();
 
+    String name = authentication.getName();
+
+    String nameidType = NameIDType.UNSPECIFIED;
+
+    if (name.contains("@")) {
+      nameidType = NameIDType.EMAIL;
+    }
+
+    if (name.contains("==")) {
+      String[] components = name.split("==", 1);
+      nameidType = components[0];
+    }
+
     SAMLPrincipal principal = new SAMLPrincipal(
-      authentication.getName(),
-      authentication.getName().contains("@") ? NameIDType.EMAIL : NameIDType.UNSPECIFIED,
+      name,
+      nameidType,
       attributes(authentication.getName()),
       idpConfiguration.getSpEntityId(),
       null,

--- a/mujina-idp/src/main/java/mujina/idp/SsoController.java
+++ b/mujina-idp/src/main/java/mujina/idp/SsoController.java
@@ -77,7 +77,7 @@ public class SsoController {
     }
 
     if (name.contains("==")) {
-      String[] components = name.split("==", 1);
+      String[] components = name.split("==", 2);
       nameidType = components[0];
     }
 
@@ -110,7 +110,7 @@ public class SsoController {
     }
 
     if (name.contains("==")) {
-      String[] components = name.split("==", 1);
+      String[] components = name.split("==", 2);
       nameidType = components[0];
     }
 

--- a/mujina-idp/src/main/java/mujina/idp/SsoController.java
+++ b/mujina-idp/src/main/java/mujina/idp/SsoController.java
@@ -79,6 +79,7 @@ public class SsoController {
     if (name.contains("==")) {
       String[] components = name.split("==", 2);
       nameidType = components[0];
+      name = components[1];
     }
 
     SAMLPrincipal principal = new SAMLPrincipal(
@@ -112,6 +113,7 @@ public class SsoController {
     if (name.contains("==")) {
       String[] components = name.split("==", 2);
       nameidType = components[0];
+      name = components[1];
     }
 
     SAMLPrincipal principal = new SAMLPrincipal(

--- a/mujina-idp/src/main/java/mujina/idp/SsoController.java
+++ b/mujina-idp/src/main/java/mujina/idp/SsoController.java
@@ -68,9 +68,23 @@ public class SsoController {
 
     String assertionConsumerServiceURL = idpConfiguration.getAcsEndpoint() != null ? idpConfiguration.getAcsEndpoint() : authnRequest.getAssertionConsumerServiceURL();
 
+    String name = authentication.getName();
+
+    String nameidType = NameIDType.UNSPECIFIED;
+
+    if (name.contains("@")) {
+      nameidType = NameIDType.EMAIL;
+    }
+
+    if (name.contains("=>")) {
+      String[] components = name.split("=>", 1);
+      name = components[1];
+      nameidType = components[0];
+    }
+
     SAMLPrincipal principal = new SAMLPrincipal(
-      authentication.getName(),
-      authentication.getName().contains("@") ? NameIDType.EMAIL : NameIDType.UNSPECIFIED,
+      name,
+      nameidType,
       attributes(authentication.getName()),
       authnRequest.getIssuer().getValue(),
       authnRequest.getID(),


### PR DESCRIPTION
This is a very hacky approach to allowing the test runner to specify that the nameid format can be something explicit, and the attribute name format can also be controlled explclitly. Essentially, for the nameid, you set the value of the name to be <nameid-format>==<name value>. For the attribute names, you set the attribute name to <format>==<attribute name>.

Tested via integration into test runner.